### PR TITLE
Fix for the ReDOS vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Jason Miller <jason@developit.ca>",
   "license": "Proprietary",
   "dependencies": {
-    "babel": "^5.8.21",
+    "babel": "^6.0.0",
     "body-parser": "^1.13.3",
     "compression": "^1.5.2",
     "cors": "^2.7.1",


### PR DESCRIPTION
peachme is currently affected by the high-severity [ReDOS vulnerability](https://snyk.io/vuln/npm:minimatch:20160620). 

Vulnerable module: `minimatch`
Introduced through: `babel`

This PR fixes the ReDOS vulnerability by upgrading `babel` to version 6.0.0

Check out the [Snyk test report](https://snyk.io/test/github/developit/peachme) to review other vulnerabilities that affect this repo. 

[Watch the repo](https://snyk.io/add) to 
- get alerts if newly disclosed vulnerabilities affect this repo in the future. 
- generate pull requests with the fixes you want, or let us do the work: when a newly disclosed vulnerability affects you, we'll submit a fix to you right away. 

Stay secure, 
The Snyk team
